### PR TITLE
drop updated as primary sort criterion for references datatable

### DIFF
--- a/glottolog3/datatables.py
+++ b/glottolog3/datatables.py
@@ -300,8 +300,8 @@ class Refs(Sources):
 
     def default_order(self):
         if self.language and self.language.level != LanguoidLevel.family:
-            return Source.pages_int.desc().nullslast(), Source.pk.desc()            
-        return Source.updated.desc(), Source.pk.desc()
+            return Source.pages_int.desc().nullslast(), Source.pk.desc()
+        return Source.pk.desc()
 
     def col_defs(self):
         cols = [DetailsRowLinkCol(self, 'd', button_text='citation')]


### PR DESCRIPTION
As we rebuild the whole db now every time we relase a new version, the `updated` column values are all the same (start time of the transaction: we could in principle switch to `statement_timestamp()` or `clock_timestamp()` but that would just give us the same order as `pk`).

Dropping it from the `order_by` halves the query time for http://glottolog.org/langdoc on my installation (order stays the same).