### PR TITLE
Aesinfo

### DIFF
--- a/glottolog3/templates/about.mako
+++ b/glottolog3/templates/about.mako
@@ -36,6 +36,14 @@
         A table of source bibliographies for Glottolog is available at
         <a href="${request.route_url('providers')}">References information</a>.
     </p>
+    <p>
+    The Agglomerated Endangerment Status (AES) is derived from the databases of
+    ${h.external_link("http://www.endangeredlanguages.com", label="The Catalogue of Endangered Languages (ELCat)")}
+    ,
+    ${h.external_link("http://www.unesco.org/languages-atlas/", label="UNESCO Atlas of the World's Languages in Danger")}
+    and
+    ${h.external_link("http://www.ethnologue.com", label="Ethnologue")}. For more information see ${h.link(req, ref)}.
+    </p>
 </div>
 <div class="span4 well well-small">
     <img src="${request.static_url('glottolog3:static/Spitzweg.jpg')}"/>

--- a/glottolog3/templates/glottologmeta.mako
+++ b/glottolog3/templates/glottologmeta.mako
@@ -520,6 +520,7 @@
         <%util:section title="Acknowledgements" prefix="">
             <p>Thanks </p>
             <ul class="itemize1">
+                <li class="itemize">To Hedvig Skirgård for miscellaneous corrections and issued raised</li>
                 <li class="itemize">To Tim Usher for many points of dicussion re Papuan languages</li>
                 <li class="itemize">To Mark Donohue for many points of dicussion re Papuan and Austronesian languages
                 </li>

--- a/glottolog3/templates/glottologmeta.mako
+++ b/glottolog3/templates/glottologmeta.mako
@@ -501,6 +501,22 @@
                 Glottolog never retires Glottocodes and keeps them also for bookkeeping purposes.
             </p>
         </%util:section>
+ 
+ 
+
+        <%util:section title="Agglomerated Endangerment Status (AES)" prefix="">
+        <p>
+    The Agglomerated Endangerment Status (AES) is derived from the databases of
+    ${h.external_link("http://www.endangeredlanguages.com", label="The Catalogue of Endangered Languages (ELCat)")}
+    ,
+    ${h.external_link("http://www.unesco.org/languages-atlas/", label="UNESCO Atlas of the World's Languages in Danger")}
+    and
+    ${h.external_link("http://www.ethnologue.com", label="Ethnologue")}. For more information see ${h.link(req, ref)}.
+</p>
+        </%util:section>
+        
+        
+        
         <%util:section title="Acknowledgements" prefix="">
             <p>Thanks </p>
             <ul class="itemize1">


### PR DESCRIPTION
Added AES info as prompted by Steve Moran. I think this is motivated since AES is displayed in Glottolog itself and not just in GlottoScope.